### PR TITLE
Add readme to docs

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
   },
   "scripts": {
     "build": "rimraf dist && tsc",
-    "build:docs": "rimraf docs && typedoc --out docs --exclude \"**/*.spec.ts\" --mode file --readme none",
+    "build:docs": "rimraf docs && typedoc --out docs --exclude \"**/*.spec.ts\" --mode file --readme README.md",
     "deploy:docs": "gh-pages -d docs",
     "lint": "tslint -p ./tsconfig.lint.json -t stylish",
     "prettier:ts": "prettier --parser typescript --single-quote true --trailing-comma es5 --write 'src/**/*.ts'",


### PR DESCRIPTION
<!-- Help us out by ensuring the following. -->
## Pull request checklist
- [ ] Addresses an existing issue: Fixes #0000
- [x] Your changes are well-tested and test coverage does not degrade.<sup>1</sup>

<!-- Tell us what this pull request does. -->
## Description
This adds README.md to our generated docs.  See http://typedoc.org/guides/usage/#readme


---
1. You can use `yarn test --coverage` to generate a coverage report.
