### PR TITLE
Properly extend Error

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,5 +1,28 @@
 /* tslint:disable:max-classes-per-file */
-export class AddressNotFoundError extends Error {}
-export class BadMethodCallError extends Error {}
-export class InvalidDbBufferError extends Error {}
-export class ValueError extends Error {}
+export class AddressNotFoundError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = this.constructor.name;
+  }
+}
+
+export class BadMethodCallError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = this.constructor.name;
+  }
+}
+
+export class InvalidDbBufferError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = this.constructor.name;
+  }
+}
+
+export class ValueError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = this.constructor.name;
+  }
+}


### PR DESCRIPTION
This changes the error name from `Error` to the name of the custom error