### PR TITLE
Fixed wrong return type for country method

### DIFF
--- a/src/readerModel.ts
+++ b/src/readerModel.ts
@@ -56,7 +56,7 @@ export default class ReaderModel {
    * @throws {AddressNotFoundError} Throws an error when the IP address isn't found in the database
    * @throws {ValueError} Throws an error when the IP address isn't valid
    */
-  public country(ipAddress: string): models.City {
+  public country(ipAddress: string): models.Country {
     return this.modelFor(models.Country, 'Country', ipAddress, 'country()');
   }
 


### PR DESCRIPTION
<!-- Help us out by ensuring the following. -->
## Pull request checklist
- [X ] Your changes are well-tested and test coverage does not degrade

<!-- Tell us what this pull request does. -->
## Description
Simple fix on return type for country method that was declared as returning instance of City instead of Country. That could lead to some false positive errors during library implementation.
