### PR TITLE
Local path prefixes in docs are sanitized

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,6 @@ typings/
 
 # next.js build output
 .next
+
+# Text editor backup files
+*~

--- a/bin/sanitize-doc-refs.sh
+++ b/bin/sanitize-doc-refs.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -eu -o pipefail
+
+function sanitize_paths_in {
+    echo "Sanitizing paths in: $1"
+    sed -i -E 's%(^|[^a-zA-Z0-9:/])/[^>"]+/GeoIP2-node/%\1GeoIP2-node/%g' $1
+}
+
+for path in $(find docs -name *.html); do
+    if grep -qE '[^a-zA-Z0-9:/]/[^>"]+/GeoIP2-node/' $path; then
+       sanitize_paths_in $path
+    fi
+done

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   },
   "scripts": {
     "build": "rimraf dist && tsc",
-    "build:docs": "rimraf docs && typedoc --out docs --exclude \"**/*.spec.ts\" --mode file --readme README.md",
+    "build:docs": "rimraf docs && typedoc --out docs --exclude \"**/*.spec.ts\" --mode file --readme README.md && ./bin/sanitize-doc-refs.sh",
     "deploy:docs": "gh-pages -d docs",
     "lint": "tslint -p ./tsconfig.lint.json -t stylish",
     "prettier:ts": "prettier --parser typescript --single-quote true --trailing-comma es5 --write 'src/**/*.ts'",


### PR DESCRIPTION
## Pull request checklist
- Addresses an existing but unreported issue
- No tests added; test coverage remains at 100%

## Description
When the docs are built with `yarn docs:build`, some source definition references are made to the absolute path of the file on the machine on which the docs are built. This results in information about a developer's machine being incorporated into the docs, which is not ideal. This PR adds a filter in the `docs:build` script that removes those local path prefixes.
