### PR TITLE
Use package.json to get version

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@maxmind/geoip2-node",
   "version": "0.7.0",
   "description": "Node.js API for GeoIP2 webservice client and database reader",
-  "main": "dist/index.js",
+  "main": "dist/src/index.js",
   "homepage": "https://github.com/maxmind/GeoIP2-node",
   "repository": {
     "type": "git",

--- a/src/webServiceClient.ts
+++ b/src/webServiceClient.ts
@@ -1,6 +1,7 @@
 import http = require('http');
 import https = require('https');
 import mmdb = require('maxmind');
+import { version } from '../package.json';
 import * as models from './models';
 import { WebServiceClientError } from './types';
 
@@ -84,7 +85,7 @@ export default class WebServiceClient {
       auth: `${this.accountID}:${this.licenseKey}`,
       headers: {
         Accept: 'application/json',
-        'User-Agent': `GeoIP2-node/${process.env.npm_package_version}`,
+        'User-Agent': `GeoIP2-node/${version}`,
       },
       host: this.host,
       method: 'GET',


### PR DESCRIPTION
### Issue
We were sending the wrong package version in our User-Agent headers.

### Fix
Use package.json to get client library version.
