### PR TITLE
Fix path to types

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "mmdb"
   ],
   "files": ["dist"],
-  "types": "dist/index.d.ts",
+  "types": "dist/src/index.d.ts",
   "devDependencies": {
     "@types/jest": "^24.0.9",
     "@types/lodash.set": "^4.3.4",


### PR DESCRIPTION
<!-- Tell us what this pull request does. -->
## Description
This fixes the path to the types file


---
1. You can use `yarn test --coverage` to generate a coverage report.
