### PR TITLE
Add city.names.en, postal.code to City Example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,8 @@ Reader.open('/usr/local/share/GeoIP/GeoIP2-City.mmdb').then(reader => {
   const response = reader.city('128.101.101.101');
 
   console.log(response.country.isoCode); // 'US'
+  console.log(response.city.names.en); // 'Minneapolis'
+  console.log(response.postal.code); // '55407'
 });
 ```
 


### PR DESCRIPTION
## Description
Since `response.city` is not used in [City Example](https://github.com/maxmind/GeoIP2-node/tree/d2c3a6f6f45ac15a5822dee0067c2e753620a7ea#city-example), I added the example using city and postal.
