### PR TITLE
Fix ambiguity

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import Reader from './reader';
 import WebServiceClient from './webServiceClient';
+import ReaderModel from './readerModel';
 
-export { Reader, WebServiceClient };
+export { Reader, ReaderModel, WebServiceClient };
 export * from './records';
 export * from './models';

--- a/src/models/City.ts
+++ b/src/models/City.ts
@@ -8,15 +8,15 @@ export default class City extends Country {
   /**
    * The city for the requested IP address.
    */
-  public readonly city: records.CityRecord | {};
+  public readonly city?: records.CityRecord;
   /**
    * The location for the requested IP address.
    */
-  public readonly location: records.LocationRecord | {};
+  public readonly location?: records.LocationRecord;
   /**
    * The postal object for the requested IP address.
    */
-  public readonly postal: records.PostalRecord | {};
+  public readonly postal?: records.PostalRecord;
   /**
    * An array of SubdivisionsRecord objects representing the country subdivisions for
    * the requested IP address. The number and type of subdivisions varies by
@@ -25,7 +25,7 @@ export default class City extends Country {
    * (smallest). If the response did not contain any subdivisions, this method
    * returns an empty array.
    */
-  public readonly subdivisions: records.SubdivisionsRecord[] | [];
+  public readonly subdivisions?: records.SubdivisionsRecord[];
 
   /**
    * Instantiates a "City" using fields from the response
@@ -40,9 +40,9 @@ export default class City extends Country {
       exclude: [/\-/],
     }) as unknown) as City;
 
-    this.city = camelcaseResponse.city || {};
-    this.location = camelcaseResponse.location || {};
-    this.postal = camelcaseResponse.postal || {};
-    this.subdivisions = camelcaseResponse.subdivisions || [];
+    this.city = camelcaseResponse.city || undefined;
+    this.location = camelcaseResponse.location || undefined;
+    this.postal = camelcaseResponse.postal || undefined;
+    this.subdivisions = camelcaseResponse.subdivisions || undefined;
   }
 }

--- a/src/models/Country.ts
+++ b/src/models/Country.ts
@@ -7,28 +7,28 @@ export default class Country {
   /**
    * The continent for the requested IP address.
    */
-  public readonly continent: records.ContinentRecord | {};
+  public readonly continent?: records.ContinentRecord;
   /**
    * The country for the requested IP address. This object represents the
    * country where MaxMind believes the end user is located.
    */
-  public readonly country: records.CountryRecord | {};
+  public readonly country?: records.CountryRecord;
   /**
    * The MaxMind record containing data related to your account.
    */
-  public readonly maxmind: records.MaxMindRecord | {};
+  public readonly maxmind?: records.MaxMindRecord;
   /**
    * The registered country record for the requested IP address. This record
    * represents the country where the ISP has registered a given IP block and
    * may differ from the user's country.
    */
-  public readonly registeredCountry: records.RegisteredCountryRecord | {};
+  public readonly registeredCountry?: records.RegisteredCountryRecord;
   /**
    * The represented country record for the requested IP address. The
    * represented country is used for things like military bases or embassies.
    * It is only present when the represented country differs from the country.
    */
-  public readonly representedCountry: records.RepresentedCountryRecord | {};
+  public readonly representedCountry?: records.RepresentedCountryRecord;
   /**
    * The traits for the requested IP address.
    */
@@ -45,13 +45,13 @@ export default class Country {
       exclude: [/\-/],
     }) as unknown) as Country;
 
-    this.continent = camelcaseResponse.continent || {};
-    this.country = camelcaseResponse.country || {};
-    this.maxmind = camelcaseResponse.maxmind || {};
+    this.continent = camelcaseResponse.continent || undefined;
+    this.country = camelcaseResponse.country || undefined;
+    this.maxmind = camelcaseResponse.maxmind || undefined;
     this.registeredCountry =
       this.setBooleanRegisteredCountry(camelcaseResponse.registeredCountry) ||
-      {};
-    this.representedCountry = camelcaseResponse.representedCountry || {};
+      undefined;
+    this.representedCountry = camelcaseResponse.representedCountry || undefined;
     this.traits = this.setBooleanTraits(camelcaseResponse.traits || {});
   }
 

--- a/src/readerModel.spec.ts
+++ b/src/readerModel.spec.ts
@@ -54,7 +54,7 @@ describe('ReaderModel', () => {
           longitude: -1.25,
           timeZone: 'Europe/London',
         },
-        maxmind: {},
+        maxmind: undefined,
         postal: {
           code: 'OX1',
         },
@@ -73,7 +73,7 @@ describe('ReaderModel', () => {
             'zh-CN': '法国',
           },
         },
-        representedCountry: {},
+        representedCountry: undefined,
         subdivisions: [
           {
             geonameId: 6269131,
@@ -129,13 +129,13 @@ describe('ReaderModel', () => {
             en: 'Boxford',
           },
         },
-        continent: {},
-        country: {},
+        continent: undefined,
+        country: undefined,
         location: undefined,
-        maxmind: {},
+        maxmind: undefined,
         postal: undefined,
-        registeredCountry: {},
-        representedCountry: {},
+        registeredCountry: undefined,
+        representedCountry: undefined,
         subdivisions: undefined,
         traits: {
           ipAddress: '2.2.3.1',
@@ -180,12 +180,12 @@ describe('ReaderModel', () => {
             'zh-CN': '欧洲',
           },
         },
-        country: {},
+        country: undefined,
         location: undefined,
-        maxmind: {},
+        maxmind: undefined,
         postal: undefined,
-        registeredCountry: {},
-        representedCountry: {},
+        registeredCountry: undefined,
+        representedCountry: undefined,
         subdivisions: undefined,
         traits: {
           ipAddress: '2.3.3.1',
@@ -278,7 +278,7 @@ describe('ReaderModel', () => {
             'zh-CN': '英国',
           },
         },
-        maxmind: {},
+        maxmind: undefined,
         registeredCountry: {
           geonameId: 3017382,
           isInEuropeanUnion: true,
@@ -294,7 +294,7 @@ describe('ReaderModel', () => {
             'zh-CN': '法国',
           },
         },
-        representedCountry: {},
+        representedCountry: undefined,
         traits: {
           ipAddress: '2.125.160.216',
           isAnonymous: false,
@@ -585,7 +585,7 @@ describe('ReaderModel', () => {
           longitude: -1.25,
           timeZone: 'Europe/London',
         },
-        maxmind: {},
+        maxmind: undefined,
         postal: {
           code: 'OX1',
           confidence: 20,
@@ -605,7 +605,7 @@ describe('ReaderModel', () => {
             'zh-CN': '法国',
           },
         },
-        representedCountry: {},
+        representedCountry: undefined,
         subdivisions: [
           {
             confidence: 70,

--- a/src/readerModel.spec.ts
+++ b/src/readerModel.spec.ts
@@ -131,12 +131,12 @@ describe('ReaderModel', () => {
         },
         continent: {},
         country: {},
-        location: {},
+        location: undefined,
         maxmind: {},
-        postal: {},
+        postal: undefined,
         registeredCountry: {},
         representedCountry: {},
-        subdivisions: [],
+        subdivisions: undefined,
         traits: {
           ipAddress: '2.2.3.1',
           isAnonymous: false,
@@ -165,7 +165,7 @@ describe('ReaderModel', () => {
       const model: any = reader.city('2.3.3.1');
 
       const expected = {
-        city: {},
+        city: undefined,
         continent: {
           code: 'EU',
           geonameId: 6255148,
@@ -181,12 +181,12 @@ describe('ReaderModel', () => {
           },
         },
         country: {},
-        location: {},
+        location: undefined,
         maxmind: {},
-        postal: {},
+        postal: undefined,
         registeredCountry: {},
         representedCountry: {},
-        subdivisions: [],
+        subdivisions: undefined,
         traits: {
           ipAddress: '2.3.3.1',
           isAnonymous: false,


### PR DESCRIPTION
<!-- Help us out by ensuring the following. -->
## Pull request checklist
- [x] Addresses an existing issue: Fixes #305 
- [x] Your changes are well-tested and test coverage does not degrade.<sup>1</sup>

<!-- Tell us what this pull request does. -->
## Description
### This is a breaking change

Return `undefined` instead of empty objects when accessing `country` or `city` model properties