### PR TITLE
Add node v14 and v15 to test gh action

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,8 +1,10 @@
 name: "Code scanning - action"
 
 on:
-  push:
   pull_request:
+  push:
+    branches:
+      - master
   schedule:
     - cron: '0 3 * * 6'
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,7 +1,9 @@
 name: Lint
 on:
-  push:
   pull_request:
+  push:
+    branches:
+      - master
   schedule:
     - cron: '3 0 * * SUN'
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: [10, 12]
+        version: [10, 12, 14, 15]
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,9 @@
 name: Run tests
 on:
-  push:
   pull_request:
+  push:
+    branches:
+      - master
   schedule:
     - cron: '3 2 * * SUN'
 jobs:


### PR DESCRIPTION
<!-- Help us out by ensuring the following. -->
## Pull request checklist
- [x ] Your changes are well-tested and test coverage does not degrade.<sup>1</sup>

<!-- Tell us what this pull request does. -->
## Description
Adds node v14 and v15 to our GH test action


---
1. You can use `yarn test --coverage` to generate a coverage report.
