### PR TITLE
Fix typedocs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,7 @@ jobs:
       - run: yarn install
       - run: yarn test --coverage
       - run: yarn build
+      - run: yarn build:docs
       - run: yarn link
       - run: yarn
         working-directory: e2e/js

--- a/package.json
+++ b/package.json
@@ -53,8 +53,7 @@
     "*.json": ["prettier --parser json --write", "git add"],
     "*.ts": [
       "prettier --parser typescript --single-quote true --trailing-comma es5 --write",
-      "tslint -p tsconfig.lint.json -t stylish",
-      "git add"
+      "tslint -p tsconfig.lint.json -t stylish"
     ]
   },
   "publishConfig": {

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   },
   "scripts": {
     "build": "rimraf dist && tsc",
-    "build:docs": "rimraf docs && typedoc --out docs --exclude \"**/*.spec.ts\" --mode file --readme README.md && ./bin/sanitize-doc-refs.sh",
+    "build:docs": "rimraf docs && typedoc src/index.ts --out docs --exclude \"**/*.spec.ts\" --readme README.md && ./bin/sanitize-doc-refs.sh",
     "deploy:docs": "gh-pages -d docs",
     "lint": "tslint -p ./tsconfig.lint.json -t stylish",
     "prettier:ts": "prettier --parser typescript --single-quote true --trailing-comma es5 --write 'src/**/*.ts'",


### PR DESCRIPTION
<!-- Help us out by ensuring the following. -->
## Pull request checklist
- [x] Your changes are well-tested and test coverage does not degrade.<sup>1</sup>

<!-- Tell us what this pull request does. -->
## Description
The `typedoc` library was updated, and its API changed. This PR fixes the `build:docs` command, and adds it to our test suite just to make sure we don't have regressions like this in the future.

I also made a fix to our `lint-staged` config to get rid of an annoying CLI warning.


---
1. You can use `yarn test --coverage` to generate a coverage report.
