### PR TITLE
Harden npm

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,6 +14,6 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 16
-      - run: npm install
+      - run: npm ci
       - run: npm run lint
       - run: npm run prettier:ci

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,18 +19,18 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.version }}
-      - run: npm install
+      - run: npm ci
       - run: npm test --coverage
       - run: npm run build
       - run: npm run build:docs
       - run: npm link
-      - run: npm install
+      - run: npm ci
         working-directory: e2e/js
       - run: npm link '@maxmind/geoip2-node'
         working-directory: e2e/js
       - run: npx jest
         working-directory: e2e/js
-      - run: npm install
+      - run: npm ci
         working-directory: e2e/ts
       - run: npm link '@maxmind/geoip2-node'
         working-directory: e2e/ts

--- a/README.dev.md
+++ b/README.dev.md
@@ -1,4 +1,4 @@
-Steps for releasing:
+## Steps for releasing:
 
 1. Review open issues and PRs to see if any can easily be fixed, closed, or
    merged.
@@ -16,3 +16,7 @@ Steps for releasing:
 9. Tag the release, e.g. `git tag -a v1.2.3 -m v1.2.3`
 10. Push the tag: `git push --tags`
 11. Create the release on GitHub. You can use the web interface.
+
+## Set up pre-commit hooks
+
+`npm run setup` to install husky pre-commit hooks

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,6 @@
     "": {
       "name": "@maxmind/geoip2-node",
       "version": "4.2.0",
-      "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
         "ip6addr": "^0.2.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,6 @@
         "lint-staged": "^15.0.1",
         "lodash": "^4.17.11",
         "nock": "^13.0.2",
-        "pinst": "^3.0.0",
         "prettier": "^3.0.0",
         "ts-jest": "^29.1.0",
         "typedoc": "^0.25.0",
@@ -2616,9 +2615,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
-      "engines": [
-        "node >=0.6.0"
-      ]
+      "engines": ["node >=0.6.0"]
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -2810,9 +2807,7 @@
       "dev": true,
       "hasInstallScript": true,
       "optional": true,
-      "os": [
-        "darwin"
-      ],
+      "os": ["darwin"],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
@@ -3987,9 +3982,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-2.0.2.tgz",
       "integrity": "sha512-gqXddjPqQ6G40VdnI6T6yObEC+pDNvyP95wdQhkWkg7crHH3km5qP1FsOXEkzEQwnz6gz5qGTn1c2Y52wP3OyQ==",
-      "engines": [
-        "node >=0.6.0"
-      ],
+      "engines": ["node >=0.6.0"],
       "dependencies": {
         "assert-plus": "1.0.0",
         "extsprintf": "1.3.0",
@@ -4839,19 +4832,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/pinst": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/pinst/-/pinst-3.0.0.tgz",
-      "integrity": "sha512-cengSmBxtCyaJqtRSvJorIIZXMXg+lJ3sIljGmtBGUVonMnMsVJbnzl6jGN1HkOWwxNuJynCJ2hXxxqCQrFDdw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "bin": {
-        "pinst": "bin.js"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
     "node_modules/pirates": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.5.tgz",
@@ -5697,9 +5677,7 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-      "engines": [
-        "node >=0.6.0"
-      ],
+      "engines": ["node >=0.6.0"],
       "dependencies": {
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
@@ -9466,12 +9444,6 @@
       "requires": {
         "pinkie": "^2.0.0"
       }
-    },
-    "pinst": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/pinst/-/pinst-3.0.0.tgz",
-      "integrity": "sha512-cengSmBxtCyaJqtRSvJorIIZXMXg+lJ3sIljGmtBGUVonMnMsVJbnzl6jGN1HkOWwxNuJynCJ2hXxxqCQrFDdw==",
-      "dev": true
     },
     "pirates": {
       "version": "4.0.5",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "lint-staged": "^15.0.1",
     "lodash": "^4.17.11",
     "nock": "^13.0.2",
-    "pinst": "^3.0.0",
     "prettier": "^3.0.0",
     "ts-jest": "^29.1.0",
     "typedoc": "^0.25.0",
@@ -64,11 +63,10 @@
     "prettier:ts": "prettier --parser typescript --single-quote true --trailing-comma es5 --write 'src/**/*.ts'",
     "prettier:ci": "prettier --parser typescript --single-quote true --trailing-comma es5 --list-different 'src/**/*.ts'",
     "prettier:json": "prettier --parser json --write '**/*.json'",
+    "setup": "husky install",
     "test": "jest",
     "test:watch": "jest --watch",
-    "postinstall": "husky install",
-    "prepublishOnly": "npm run build && npm run test && npm run lint && npm run build:docs && npm run deploy:docs && pinst --disable",
-    "postpublish": "pinst --enable"
+    "prepublishOnly": "npm run build && npm run test && npm run lint && npm run build:docs && npm run deploy:docs"
   },
   "dependencies": {
     "ip6addr": "^0.2.5",


### PR DESCRIPTION
### Remove pinst

Pinst modifies package.json before publishing.  This could trigger manifest confusion alerts since the tarballed package.json won't match what's in the source code's package.json.  Even if it doesn't, pinst isn't integral to this package.

### npm ci
This ensures that our CI environment does a clean install of deps
