### PR TITLE
Fixes for read-only GITHUB_TOKEN in workflows

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -2,9 +2,6 @@ name: "Code scanning - action"
 
 on:
   pull_request:
-  push:
-    branches:
-      - main
   schedule:
     - cron: '0 3 * * 6'
 


### PR DESCRIPTION
- **Validate lockfile**
- **Update lockfile**
- **Only run CodeQL on pull requests**
