### PR TITLE
Disable npm caching in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,7 @@ jobs:
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
+          package-manager-cache: false
       - run: npm ci
       - run: npm test
       - run: npm run lint
@@ -44,6 +45,7 @@ jobs:
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
+          package-manager-cache: false
           registry-url: 'https://registry.npmjs.org'
       - run: npm install -g npm@latest
       - run: npm ci


### PR DESCRIPTION
zizmor reports `cache-poisoning` findings for `release.yml` (it has a `release: published` trigger and publishes to npm): a poisoned cache entry restored during a release run could taint the published package. This disables setup-node's package-manager cache in both jobs of that workflow.

This also closes the open zizmor code-scanning alerts on `release.yml`, which would otherwise fail the code-scanning check on any future PR touching those lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal build configuration to improve release consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->