### PR TITLE
Add residential proxy data to anonymizer object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,22 @@
 CHANGELOG
 =========
 
+7.1.0 (unreleased)
+------------------
+
+* A new `residential` property has been added to the `anonymizer` object in
+  the `Insights` response model. This contains residential proxy data for
+  the network and is available from the GeoIP2 Insights web service only.
+  The `residential` property may be populated even when no other
+  `anonymizer` properties are set. The `residential` object includes the
+  following properties:
+  * `confidence`: A score (1-99) representing MaxMind's confidence that the
+    network is an actively used residential proxy
+  * `networkLastSeen`: The last day (YYYY-MM-DD) the network was sighted in
+    our analysis of residential proxies
+  * `providerName`: The name of the residential proxy provider associated
+    with the network
+
 7.0.0 (2026-06-29)
 ------------------
 

--- a/fixtures/geoip2.json
+++ b/fixtures/geoip2.json
@@ -139,6 +139,11 @@
     "is_residential_proxy": false,
     "is_tor_exit_node": false,
     "network_last_seen": "2025-04-14",
-    "provider_name": "NordVPN"
+    "provider_name": "NordVPN",
+    "residential": {
+      "confidence": 82,
+      "network_last_seen": "2026-05-11",
+      "provider_name": "quickshift"
+    }
   }
 }

--- a/src/records.ts
+++ b/src/records.ts
@@ -218,6 +218,32 @@ export interface SubdivisionsRecord {
 }
 
 /**
+ * Contains data for one type of anonymizer detection, currently residential
+ * proxies. These records are nested within the anonymizer record, such as
+ * `residential`, and additional feeds may be added in the future. This
+ * record is only available from the GeoIP Insights web service.
+ */
+export interface AnonymizerFeedRecord {
+  /**
+   * A score ranging from 1 to 99 that represents our percent confidence that
+   * the network is currently part of this anonymizer feed. This value is
+   * only available from GeoIP Insights.
+   */
+  readonly confidence?: number;
+  /**
+   * The last day that the network was sighted in our analysis of this
+   * anonymizer feed. The date is in ISO 8601 format (YYYY-MM-DD). This value
+   * is only available from GeoIP Insights.
+   */
+  readonly networkLastSeen?: string;
+  /**
+   * The name of the provider associated with the network in this anonymizer
+   * feed. This value is only available from GeoIP Insights.
+   */
+  readonly providerName?: string;
+}
+
+/**
  * Contains data for the anonymizer record associated with an IP address.
  * This record is only available from the GeoIP Insights web service.
  */
@@ -271,6 +297,12 @@ export interface AnonymizerRecord {
    * This value is only available from GeoIP Insights.
    */
   readonly providerName?: string;
+  /**
+   * Residential proxy data for the network. This may be populated even when
+   * no other anonymizer properties are set. This value is only available
+   * from GeoIP Insights.
+   */
+  readonly residential?: AnonymizerFeedRecord;
 }
 
 /**

--- a/src/webServiceClient.spec.ts
+++ b/src/webServiceClient.spec.ts
@@ -346,7 +346,7 @@ describe('WebServiceClient', () => {
 
     it('returns an insight class', async () => {
       const ip = '8.8.8.8';
-      expect.assertions(107);
+      expect.assertions(110);
 
       const { client, requests } = clientWith(() =>
         jsonResponse(200, testFixture)
@@ -474,6 +474,12 @@ describe('WebServiceClient', () => {
       expect(got.anonymizer!.isTorExitNode).toEqual(false);
       expect(got.anonymizer!.networkLastSeen).toEqual('2025-04-14');
       expect(got.anonymizer!.providerName).toEqual('NordVPN');
+
+      expect(got.anonymizer!.residential!.confidence).toEqual(82);
+      expect(got.anonymizer!.residential!.networkLastSeen).toEqual(
+        '2026-05-11'
+      );
+      expect(got.anonymizer!.residential!.providerName).toEqual('quickshift');
     });
   });
 


### PR DESCRIPTION
## Summary

The GeoIP Insights web service is adding a `residential` sub-object to the `anonymizer` object. It contains residential proxy data for the network and may be populated even when no other anonymizer properties are set.

- New reusable record for the feed shape (`confidence`, `network_last_seen`, `provider_name`) named `AnonymizerFeed`, so future anonymizer feeds can share it
- New `residential` property on the `Anonymizer` record
- Tests, fixtures, and changelog updated

(The reusable interface is named `AnonymizerFeedRecord` per this repo's record-interface naming convention.)

## Testing

`npm test`, `npm run lint`, `npm run build`, and `npm run prettier:ci` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
