### PR TITLE
Cover e2e npm manifests in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,9 @@
 version: 2
 updates:
   - package-ecosystem: npm
-    directory: /
+    directories:
+      - /
+      - '**/*'
     schedule:
       interval: weekly
       day: monday


### PR DESCRIPTION
The npm ecosystem entry only declared `directory: /`, so scheduled version updates never looked at `e2e/js` or `e2e/ts`.

Those directories *have* been getting Dependabot **security** updates — that feature scans every manifest in the repo regardless of `dependabot.yml` — which is why the git history shows bumps there for `minimatch`, `brace-expansion`, `picomatch`, `js-yaml`, etc. But those are all deep transitive packages with advisories. The direct dependencies (`vitest`, `typescript`, and `jest`/`ts-jest` before the Vitest migration) have only ever been bumped by hand. Both e2e suites run in CI via `working-directory` in `test.yml`, so they were quietly drifting from the root's versions.

Switches the npm entry to `directories` (plural, glob-capable):

```yaml
    directories:
      - /
      - '**/*'
```

Two notes:

* Root is listed explicitly because the glob does not match the repository root — matching follows `Dir.glob` semantics, where `**/*` enumerates descendants but not `.` itself. The two entries therefore do not overlap, so there is no duplicate-PR risk.
* This matches the pattern already used for nuget in `GeoIP2-dotnet`, `MaxMind-DB-Reader-dotnet`, and `minfraud-api-dotnet`, except those repos have no root-level manifest and so only list the glob.

The `github-actions` entry is deliberately left on `directory: /`. There is an open bug, dependabot/dependabot-core#10884, where a globstar collides with the implicit `.github/workflows` path and produces duplicate PRs.

One behavior change worth expecting: the `minor-and-patch` group is applied per directory, so a week in which all three directories have updates will produce three grouped PRs instead of one. `open-pull-requests-limit: 20` is per entry rather than per directory, so the overall cap is unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency monitoring to cover the project root and nested directories.
  * Existing update scheduling and behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->